### PR TITLE
Using match instead of include

### DIFF
--- a/lib/cocoapods-catalyst-support/xcodeproj/native_target.rb
+++ b/lib/cocoapods-catalyst-support/xcodeproj/native_target.rb
@@ -44,7 +44,7 @@ module Xcodeproj::Project::Object
         new_snippet = snippet.clone
         should_uninstall = configurations.map do |string| snippet.include? string end.reduce(false) do |total, condition| total = total || condition end
         keys.each do |key|
-          lines_to_replace = snippet.filter_lines do |line| line.include? "#{key}" end.to_set.to_a
+          lines_to_replace = snippet.filter_lines do |line| line.match "\/#{key}" end.to_set.to_a
           unless lines_to_replace.empty?
             changed = true
             lines_to_replace.each do |line|


### PR DESCRIPTION
Found a bug when using MKStoreKit as a pod in the project. When for any reason the script tries to remove StoreKit.framework, it does so by looking for a line containing "StoreKit.framework". This will result in finding the line with `MKStoreKit.framework` as well.

`install_framework "${BUILT_PRODUCTS_DIR}/MKStoreKit/MKStoreKit.framework"` will be picked up.